### PR TITLE
fix: deduplicate failure notifications during phase retries

### DIFF
--- a/.claude/skills/visual-verification/SKILL.md
+++ b/.claude/skills/visual-verification/SKILL.md
@@ -8,6 +8,7 @@ description: Visual verification loop for Oxveil UI — build, launch, screensho
 ## Constraints
 
 - macOS only. Requires osascript (Accessibility permission) and screencapture (Screen Recording permission).
+- NEVER use `screencapture -w` (interactive window selection — blocks in automation). Use `screencapture -l <CGWindowID>` or `screencapture -R x,y,w,h -x`.
 - Do not invoke during TDD cycles. This is a standalone verification activity.
 - Do not commit fixes automatically. Log changes in SESSION.md. Developer reviews `git diff` after session.
 - All code paths must reach Phase 6 (Cleanup). No exceptions.
@@ -47,6 +48,7 @@ See `references/visual-verification-recipes.md` for discovery file parsing, full
 
 - **Tier 1 (reliable — use screenshots):** Element presence/absence, text content, gross layout, item count, notification visibility.
 - **Tier 2 (unreliable — verify via code review):** ThemeColor correctness, spinner animation, pixel alignment, contrast ratios.
+- **Not screenshot-verifiable:** Notification deduplication (count, suppression during retries) and timing. Verify via unit tests asserting `showErrorMessage`/`showInformationMessage` call counts. Notification message format, severity, and button labels remain Tier 1 — verify visually.
 
 ## References
 

--- a/.claude/skills/visual-verification/references/visual-verification-recipes.md
+++ b/.claude/skills/visual-verification/references/visual-verification-recipes.md
@@ -382,6 +382,9 @@ for w in windows {
 ## Screenshot Pipeline
 
 ```bash
+# NEVER use screencapture -w — it requires an interactive click and hangs in automation.
+# Always use -l (window ID) or -R (region).
+
 # Capture + resize in one pipeline
 screencapture -l "$WINDOW_ID" "$SESSION_DIR/screenshots/$SCREENSHOT_NAME.png"
 sips --resampleWidth 1568 "$SESSION_DIR/screenshots/$SCREENSHOT_NAME.png" --out "$SESSION_DIR/screenshots/$SCREENSHOT_NAME.png" > /dev/null 2>&1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@
 - NEVER `await` an external process (execFile, spawn, fetch) without a timeout in `activate()`. Use `Promise.race` with 5s timeout. A hanging CLI blocks `resolveWebviewView` and the sidebar stays on the loading spinner forever.
 - Wrap non-critical awaits in `activate()` (bridge startup, optional detection) in try-catch. Activation must always complete.
 - NEVER call ExitPlanMode without first launching and completing 2-3 critic agents. "The fix is simple" and "the plan is obvious" are not exemptions — simple plans still get reviewed. This is a hard gate, not a suggestion.
+- After critic agents complete, personally spot-check their blind spots before declaring confidence: grep for mock/call sites of changed interfaces, verify the plan's file list is complete, and trace one end-to-end code path through the fix. Do not trust critic output without verification. Critics catch design issues; mechanical blast radius is your responsibility.
 
 ## Project
 
@@ -53,7 +54,7 @@
 - After every screenshot capture, read the image and describe what you see in concrete terms. Do not assume success from blurry/small screenshots. Verify keystrokes reached the intended target by checking for typed text.
 - Run `npm run lint` and `npm test` before claiming work is complete. Pre-existing errors are not exempt — fix them.
 - Never suggest the user test something manually when you can do it yourself.
-- Critic agents before ExitPlanMode must cover: (1) root cause correctness / feasibility, (2) scope completeness / missing steps, (3) alternatives / UX impact. Run in parallel.
+- Critic agents before ExitPlanMode must cover: (1) root cause correctness / feasibility, (2) scope completeness / missing steps (when interfaces change, grep `src/test/` for all mock sites of the changed class), (3) alternatives / UX impact. Run in parallel.
 - One critic agent must always verify the plan includes `/visual-verification` for every phase that changes user-visible behavior (sidebar, status bar, webview, notifications). "This is backend logic" is not a valid exemption if the change affects what the user sees. "This is state derivation, not rendering" is not a valid exemption. Visual verification is dynamic testing — it verifies app behavior the way a real user would. Any change that alters what the user experiences requires it. Trace the call chain to the UI before deciding.
 - When reviewing interfaces that pass mutable state (wiring contexts, dependency injection), critic agents should check: are any fields stale snapshots of values that can change at runtime? Prefer getters or callbacks over copied values.
 
@@ -68,6 +69,8 @@
 - For multi-component bugs: trace the data flow backward from symptom to source before choosing where to fix.
 - Document which component owns the broken transformation before writing the fix.
 - When an issue attributes a bug to a specific function, verify the attribution. If the function's inputs are already wrong, the fix belongs upstream.
+- When adding public methods to widely-mocked classes, grep for the class/interface name across `src/test/**/*.test.ts` before writing the implementation. Update all mock sites in the same phase.
+- When adding `reset()` or cleanup logic to a stateful manager, audit the wiring closure (`sessionWiring.ts`) for local variables (`lastProgress`, `sidebarCost`, etc.) that also need resetting. Closure-scoped state is invisible to the manager.
 
 ## Continuous Improvement
 

--- a/docs/workflow/states.md
+++ b/docs/workflow/states.md
@@ -277,11 +277,11 @@ Session wiring does **not** build sidebar state internally. It receives a `build
 
 | SessionState Event | Handler Action | Targets Updated |
 |-------------------|----------------|-----------------|
-| `state-changed` → `running` | Start elapsed timer, reset cost/todo tracking | StatusBar (`running`), LiveRunPanel (auto-reveal), Sidebar (via `buildSidebarState()` + cost/todo merge), context key `oxveil.processRunning=true` |
+| `state-changed` → `running` | Start elapsed timer, reset cost/todo/notification-dedup tracking, clear `lastProgress` | StatusBar (`running`), LiveRunPanel (auto-reveal), NotificationManager (`reset()`), Sidebar (via `buildSidebarState()` + cost/todo merge), context key `oxveil.processRunning=true` |
 | `state-changed` → `done` | Stop elapsed timer, derive view from sidebar | StatusBar (`done` or `stopped` via `deriveViewState`), LiveRunPanel (`onRunFinished("done"` or `"stopped")`), Sidebar (via `buildSidebarState()`), context key `oxveil.walkthrough.hasRun=true`, archive refresh |
 | `state-changed` → `failed` | Stop elapsed timer, find failed phase | StatusBar (`failed`), LiveRunPanel (`onRunFinished("failed")`), Sidebar (via `buildSidebarState()`), archive refresh |
 | `state-changed` → `idle` | Stop elapsed timer | StatusBar (`idle`), Sidebar (via `buildSidebarState()`), context key `oxveil.processRunning=false` |
-| `phases-changed` | Update panels, notify on completions/failures | DependencyGraph, ExecutionTimeline, LiveRunPanel, StatusBar (current phase update), Sidebar (progress update) |
+| `phases-changed` | Update panels, notify on completions/failures (failures deduplicated per phase — only first failure per run notified) | DependencyGraph, ExecutionTimeline, LiveRunPanel, StatusBar (current phase update), Sidebar (progress update) |
 | `log-appended` | Extract cost/todo data from log lines | LiveRunPanel, Sidebar (progress update with cost/todos) |
 
 ### Context Keys

--- a/src/sessionWiring.ts
+++ b/src/sessionWiring.ts
@@ -62,11 +62,13 @@ export function wireSessionEvents(deps: SessionWiringDeps): void {
       to === "running",
     );
 
-    // Reset cost/todo tracking on new run
+    // Reset cost/todo/notification tracking on new run
     if (to === "running") {
       sidebarCost = 0;
       sidebarTodoDone = 0;
       sidebarTodoTotal = 0;
+      notifications.reset();
+      lastProgress = undefined;
     }
 
     switch (to) {

--- a/src/test/integration/stateSync.test.ts
+++ b/src/test/integration/stateSync.test.ts
@@ -8,6 +8,7 @@ vi.mock("vscode", () => ({
 
 import { SessionState } from "../../core/sessionState";
 import { wireSessionEvents, type SessionWiringDeps } from "../../sessionWiring";
+import { NotificationManager } from "../../views/notifications";
 import { deriveViewState } from "../../views/sidebarState";
 import type { ProgressState, StatusBarState } from "../../types";
 import type { SidebarView } from "../../views/sidebarState";
@@ -32,7 +33,7 @@ function wireDeps(
       update: (state: StatusBarState) => statusBarUpdates.push(state),
       dispose: vi.fn(),
     },
-    notifications: { onPhasesChanged: vi.fn() },
+    notifications: { onPhasesChanged: vi.fn(), reset: vi.fn() },
     elapsedTimer: { start: vi.fn(), stop: vi.fn(), elapsed: "0m" },
     isActiveSession: () => true,
     folderUri: "/test",
@@ -207,5 +208,102 @@ describe("Status bar / sidebar state sync", () => {
 
     const lastUpdate = statusBarUpdates[statusBarUpdates.length - 1];
     expect(lastUpdate.kind).toBe("stopped");
+  });
+});
+
+function makeWindow() {
+  return {
+    showInformationMessage: vi.fn().mockResolvedValue(undefined),
+    showWarningMessage: vi.fn().mockResolvedValue(undefined),
+    showErrorMessage: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function wireWithRealNotifications(
+  session: SessionState,
+  getSidebarView: () => SidebarView,
+) {
+  const statusBarUpdates: StatusBarState[] = [];
+  const mockWindow = makeWindow();
+  const notifications = new NotificationManager({ window: mockWindow });
+  const deps: SessionWiringDeps = {
+    session,
+    statusBar: {
+      update: (state: StatusBarState) => statusBarUpdates.push(state),
+      dispose: vi.fn(),
+    },
+    notifications,
+    elapsedTimer: { start: vi.fn(), stop: vi.fn(), elapsed: "0m" },
+    isActiveSession: () => true,
+    folderUri: "/test",
+    buildSidebarState: () => ({
+      view: getSidebarView(),
+      archives: [],
+    }),
+    sidebarPanel: { updateState: vi.fn(), sendProgressUpdate: vi.fn() } as any,
+  };
+  wireSessionEvents(deps);
+  return { statusBarUpdates, mockWindow, notifications };
+}
+
+describe("Notification deduplication during retries", () => {
+  it("phase fails 5 times during retry loop — notification count <= 2", () => {
+    const session = new SessionState();
+    const { mockWindow } = wireWithRealNotifications(session, () =>
+      deriveViewState("detected", session.status, false, session.progress),
+    );
+
+    // Session starts
+    session.onLockChanged({ locked: true, pid: 1 });
+
+    // Initial progress: phase 1 in_progress
+    session.onProgressChanged(
+      makeProgress([{ number: 1, title: "Setup", status: "in_progress" }]),
+    );
+
+    // 5 retry failures
+    for (let attempt = 1; attempt <= 5; attempt++) {
+      session.onProgressChanged(
+        makeProgress([{ number: 1, title: "Setup", status: "failed" }]),
+      );
+      if (attempt < 5) {
+        session.onProgressChanged(
+          makeProgress([{ number: 1, title: "Setup", status: "in_progress" }]),
+        );
+      }
+    }
+
+    expect(mockWindow.showErrorMessage.mock.calls.length).toBeLessThanOrEqual(2);
+  });
+
+  it("new session run clears failure tracking", () => {
+    const session = new SessionState();
+    const { mockWindow } = wireWithRealNotifications(session, () =>
+      deriveViewState("detected", session.status, false, session.progress),
+    );
+
+    // First session: phase 1 fails
+    session.onLockChanged({ locked: true, pid: 1 });
+    session.onProgressChanged(
+      makeProgress([{ number: 1, title: "Setup", status: "in_progress" }]),
+    );
+    session.onProgressChanged(
+      makeProgress([{ number: 1, title: "Setup", status: "failed" }]),
+    );
+
+    // Session ends
+    session.onLockChanged({ locked: false });
+
+    // New session starts (triggers reset)
+    session.reset();
+    session.onLockChanged({ locked: true, pid: 2 });
+    session.onProgressChanged(
+      makeProgress([{ number: 1, title: "Setup", status: "in_progress" }]),
+    );
+    session.onProgressChanged(
+      makeProgress([{ number: 1, title: "Setup", status: "failed" }]),
+    );
+
+    expect(mockWindow.showErrorMessage).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/test/unit/views/notifications.test.ts
+++ b/src/test/unit/views/notifications.test.ts
@@ -239,6 +239,124 @@ describe("NotificationManager", () => {
     });
   });
 
+  describe("failure deduplication", () => {
+    it("suppresses duplicate failure notifications for same phase during retries", () => {
+      const win = makeWindow();
+      const mgr = new NotificationManager({ window: win });
+
+      // Attempt 1: in_progress -> failed
+      mgr.onPhasesChanged(
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "in_progress", attempts: 1 }], totalPhases: 5 }),
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "failed", attempts: 1 }], totalPhases: 5 }),
+      );
+      expect(win.showErrorMessage).toHaveBeenCalledTimes(1);
+
+      // Retry starts: failed -> in_progress
+      mgr.onPhasesChanged(
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "failed", attempts: 1 }], totalPhases: 5 }),
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "in_progress", attempts: 2 }], totalPhases: 5 }),
+      );
+
+      // Attempt 2: in_progress -> failed (should be suppressed)
+      mgr.onPhasesChanged(
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "in_progress", attempts: 2 }], totalPhases: 5 }),
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "failed", attempts: 2 }], totalPhases: 5 }),
+      );
+
+      // Retry starts again: failed -> in_progress
+      mgr.onPhasesChanged(
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "failed", attempts: 2 }], totalPhases: 5 }),
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "in_progress", attempts: 3 }], totalPhases: 5 }),
+      );
+
+      // Attempt 3: in_progress -> failed (should be suppressed)
+      mgr.onPhasesChanged(
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "in_progress", attempts: 3 }], totalPhases: 5 }),
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "failed", attempts: 3 }], totalPhases: 5 }),
+      );
+
+      expect(win.showErrorMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it("fires separate notifications for different phases failing", () => {
+      const win = makeWindow();
+      const mgr = new NotificationManager({ window: win });
+
+      mgr.onPhasesChanged(
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "in_progress" }], totalPhases: 5 }),
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "failed" }], totalPhases: 5 }),
+      );
+
+      mgr.onPhasesChanged(
+        makeProgress({ phases: [{ number: 4, title: "Build", status: "in_progress" }], totalPhases: 5 }),
+        makeProgress({ phases: [{ number: 4, title: "Build", status: "failed" }], totalPhases: 5 }),
+      );
+
+      expect(win.showErrorMessage).toHaveBeenCalledTimes(2);
+    });
+
+    it("allows re-notification after phase completes then fails again", () => {
+      const win = makeWindow();
+      const mgr = new NotificationManager({ window: win });
+
+      // First failure
+      mgr.onPhasesChanged(
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "in_progress" }], totalPhases: 5 }),
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "failed" }], totalPhases: 5 }),
+      );
+
+      // Phase completes (recovers)
+      mgr.onPhasesChanged(
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "failed" }], totalPhases: 5 }),
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "completed" }], totalPhases: 5 }),
+      );
+
+      // Fails again — should notify since phase recovered
+      mgr.onPhasesChanged(
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "in_progress" }], totalPhases: 5 }),
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "failed" }], totalPhases: 5 }),
+      );
+
+      expect(win.showErrorMessage).toHaveBeenCalledTimes(2);
+    });
+
+    it("reset() clears tracked failures allowing fresh notifications", () => {
+      const win = makeWindow();
+      const mgr = new NotificationManager({ window: win });
+
+      mgr.onPhasesChanged(
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "in_progress" }], totalPhases: 5 }),
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "failed" }], totalPhases: 5 }),
+      );
+
+      mgr.reset();
+
+      mgr.onPhasesChanged(
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "in_progress" }], totalPhases: 5 }),
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "failed" }], totalPhases: 5 }),
+      );
+
+      expect(win.showErrorMessage).toHaveBeenCalledTimes(2);
+    });
+
+    it("first failure still includes actions and attempt suffix", () => {
+      const win = makeWindow();
+      const mgr = new NotificationManager({ window: win });
+
+      mgr.onPhasesChanged(
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "in_progress", attempts: 1 }], totalPhases: 5 }),
+        makeProgress({ phases: [{ number: 3, title: "Setup", status: "failed", attempts: 1 }], totalPhases: 5 }),
+      );
+
+      expect(win.showErrorMessage).toHaveBeenCalledWith(
+        "Phase 3 failed — Setup",
+        "View Log",
+        "Show Output",
+        "Dismiss",
+      );
+    });
+  });
+
   describe("double-spawn notification", () => {
     it("shows error notification with Stop and Force Unlock actions", () => {
       const win = makeWindow();

--- a/src/test/unit/views/sessionWiringLog.test.ts
+++ b/src/test/unit/views/sessionWiringLog.test.ts
@@ -22,7 +22,7 @@ describe("wireSessionEvents — uses buildSidebarState for sidebar updates", () 
     const deps: SessionWiringDeps = {
       session,
       statusBar: { update: vi.fn(), dispose: vi.fn() },
-      notifications: { onPhasesChanged: vi.fn() },
+      notifications: { onPhasesChanged: vi.fn(), reset: vi.fn() },
       elapsedTimer: { start: vi.fn(), stop: vi.fn(), elapsed: "0m" },
       sidebarPanel,
       isActiveSession: () => true,
@@ -51,7 +51,7 @@ describe("wireSessionEvents — log-appended handler", () => {
     deps = {
       session,
       statusBar: { update: vi.fn(), dispose: vi.fn() },
-      notifications: { onPhasesChanged: vi.fn() },
+      notifications: { onPhasesChanged: vi.fn(), reset: vi.fn() },
       elapsedTimer: { start: vi.fn(), stop: vi.fn(), elapsed: "0m" },
       sidebarPanel: { updateState: vi.fn(), sendProgressUpdate: vi.fn() } as any,
       isActiveSession: () => true,

--- a/src/test/unit/views/walkthrough.test.ts
+++ b/src/test/unit/views/walkthrough.test.ts
@@ -143,7 +143,7 @@ describe("walkthrough step completion", () => {
         session,
         statusBar: { update: vi.fn() } as any,
         liveRunPanel: { onLogAppended: vi.fn(), onProgressChanged: vi.fn(), onRunFinished: vi.fn(), reveal: vi.fn() } as any,
-        notifications: { onPhasesChanged: vi.fn() } as any,
+        notifications: { onPhasesChanged: vi.fn(), reset: vi.fn() } as any,
         elapsedTimer: {
           start: vi.fn(),
           stop: vi.fn(),
@@ -181,7 +181,7 @@ describe("walkthrough step completion", () => {
         session,
         statusBar: { update: vi.fn() } as any,
         liveRunPanel: { onLogAppended: vi.fn(), onProgressChanged: vi.fn(), onRunFinished: vi.fn(), reveal: vi.fn() } as any,
-        notifications: { onPhasesChanged: vi.fn() } as any,
+        notifications: { onPhasesChanged: vi.fn(), reset: vi.fn() } as any,
         elapsedTimer: {
           start: vi.fn(),
           stop: vi.fn(),

--- a/src/views/notifications.ts
+++ b/src/views/notifications.ts
@@ -57,9 +57,14 @@ export interface NotificationDeps {
 
 export class NotificationManager {
   private readonly _deps: NotificationDeps;
+  private _notifiedFailures = new Set<number | string>();
 
   constructor(deps: NotificationDeps) {
     this._deps = deps;
+  }
+
+  reset(): void {
+    this._notifiedFailures.clear();
   }
 
   onPhasesChanged(
@@ -73,10 +78,15 @@ export class NotificationManager {
 
     for (const t of transitions) {
       if (t.to === "completed") {
+        this._notifiedFailures.delete(t.phase);
         this._deps.window.showInformationMessage(
           `Phase ${t.phase} completed — ${t.title}`,
         );
       } else if (t.to === "failed") {
+        if (this._notifiedFailures.has(t.phase)) {
+          continue;
+        }
+        this._notifiedFailures.add(t.phase);
         const attemptSuffix =
           t.attempts !== undefined && t.attempts > 1
             ? ` (attempt ${t.attempts})`


### PR DESCRIPTION
## Summary

Closes #31

- Add per-phase failure tracking (`_notifiedFailures` Set) to `NotificationManager` — only the first failure per phase fires a notification; subsequent retry failures are suppressed
- Reset tracking on new session start (`notifications.reset()` + `lastProgress = undefined` in `state-changed → running` handler)
- Clear per-phase tracking on completion (allows re-notification after recovery)

## Changes

| File | Change |
|------|--------|
| `src/views/notifications.ts` | `_notifiedFailures` set, dedup guard, `reset()`, clear on completed |
| `src/sessionWiring.ts` | `notifications.reset()` + `lastProgress = undefined` on running |
| `src/test/unit/views/notifications.test.ts` | 5 new unit tests for deduplication |
| `src/test/integration/stateSync.test.ts` | 2 new integration tests, updated mock |
| `src/test/unit/views/sessionWiringLog.test.ts` | Updated mock with `reset` |
| `src/test/unit/views/walkthrough.test.ts` | Updated mock with `reset` |
| `docs/workflow/states.md` | Updated Event → Update Matrix |

## Test plan

- [x] 5 unit tests: dedup, different phases, recovery, reset, message format
- [x] 2 integration tests: 5-retry loop (count ≤ 2), new session clears tracking
- [x] Full suite: 870 tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)