### PR TITLE
fix: display cost tracking in sidebar (#33)

### DIFF
--- a/docs/workflow/states.md
+++ b/docs/workflow/states.md
@@ -270,7 +270,7 @@ This module connects SessionState events to all UI projections. It is the centra
 
 ### Sidebar State Delegation
 
-Session wiring does **not** build sidebar state internally. It receives a `buildSidebarState: () => SidebarState` callback (the canonical `buildFullState()` from `activateSidebar.ts`) and calls it on every state change. This ensures the sidebar always reflects live mutable state (detection status, plan detection, user choice) rather than stale snapshots captured at wiring time. The wiring only merges session-local tracking data (cost, todos) into the `session` field of the returned state.
+Session wiring does **not** build sidebar state internally. It receives a `buildSidebarState: () => SidebarState` callback (the canonical `buildFullState()` from `activateSidebar.ts`) and calls it on every state change. This ensures the sidebar always reflects live mutable state (detection status, plan detection, user choice) rather than stale snapshots captured at wiring time. Cost and todo data are written to `SidebarMutableState.cost`/`.todoDone`/`.todoTotal` by the wiring's `log-appended` handler, so `buildFullState()` includes them natively in every call.
 
 **Contract:** `buildSidebarState()` reads `SessionState.status` via the manager, so it must be called after `_transition()` sets `_status` (which it is — `_transition` sets status before emitting `state-changed`).
 
@@ -278,12 +278,12 @@ Session wiring does **not** build sidebar state internally. It receives a `build
 
 | SessionState Event | Handler Action | Targets Updated |
 |-------------------|----------------|-----------------|
-| `state-changed` → `running` | Start elapsed timer, reset cost/todo/notification-dedup tracking, clear `lastProgress` | StatusBar (`running`), LiveRunPanel (auto-reveal), NotificationManager (`reset()`), Sidebar (via `buildSidebarState()` + cost/todo merge), context key `oxveil.processRunning=true` |
+| `state-changed` → `running` | Start elapsed timer, reset `SidebarMutableState` cost/todo fields, reset notification-dedup tracking, clear `lastProgress` | StatusBar (`running`), LiveRunPanel (auto-reveal), NotificationManager (`reset()`), Sidebar (via `buildSidebarState()`), context key `oxveil.processRunning=true` |
 | `state-changed` → `done` | Stop elapsed timer, derive view from sidebar | StatusBar (`done` or `stopped` via `deriveViewState`), LiveRunPanel (`onRunFinished("done"` or `"stopped")`), Sidebar (via `buildSidebarState()`), context key `oxveil.walkthrough.hasRun=true`, archive refresh |
 | `state-changed` → `failed` | Stop elapsed timer, find failed phase | StatusBar (`failed`), LiveRunPanel (`onRunFinished("failed")`), Sidebar (via `buildSidebarState()`), archive refresh |
 | `state-changed` → `idle` | Stop elapsed timer | StatusBar (`idle`), Sidebar (via `buildSidebarState()`), context key `oxveil.processRunning=false` |
 | `phases-changed` | Update panels, notify on completions/failures (failures deduplicated per phase — only first failure per run notified) | DependencyGraph, ExecutionTimeline, LiveRunPanel, StatusBar (current phase update), Sidebar (progress update) |
-| `log-appended` | Extract cost/todo data from log lines | LiveRunPanel, Sidebar (progress update with cost/todos) |
+| `log-appended` | Extract cost/todo data from log lines, write to `SidebarMutableState.cost`/`.todoDone`/`.todoTotal` | LiveRunPanel, SidebarMutableState, Sidebar (progress update with cost/todos) |
 
 ### Context Keys
 

--- a/src/activateSidebar.ts
+++ b/src/activateSidebar.ts
@@ -37,6 +37,10 @@ export interface SidebarMutableState {
   planDetected: boolean;
   planUserChoice: PlanUserChoice;
   cachedPlanPhases: PhaseView[];
+  /** Accumulated cost from log-appended events (written by sessionWiring) */
+  cost: number;
+  todoDone: number;
+  todoTotal: number;
 }
 
 export function activateSidebar(deps: SidebarActivationDeps): SidebarActivationResult {
@@ -47,6 +51,9 @@ export function activateSidebar(deps: SidebarActivationDeps): SidebarActivationR
     planDetected: deps.initialPlanDetected,
     planUserChoice: "none",
     cachedPlanPhases: [],
+    cost: 0,
+    todoDone: 0,
+    todoTotal: 0,
   };
 
   function getArchives(): ArchiveView[] {
@@ -87,6 +94,8 @@ export function activateSidebar(deps: SidebarActivationDeps): SidebarActivationR
       } : undefined,
       session: sessionStatus === "running" || sessionStatus === "done" || sessionStatus === "failed" ? {
         elapsed: elapsedTimer.elapsed,
+        cost: state.cost > 0 ? `$${state.cost.toFixed(2)}` : undefined,
+        todos: state.todoTotal > 0 ? { done: state.todoDone, total: state.todoTotal } : undefined,
       } : undefined,
       archives: getArchives(),
     };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -204,6 +204,7 @@ export async function activate(
     getConfig: (key: string) => vscode.workspace.getConfiguration("oxveil").get(key),
     sidebarPanel,
     buildSidebarState: buildFullState,
+    sidebarMutableState: sidebarState,
   };
 
   const onArchiveDone = async () => {

--- a/src/sessionWiring.ts
+++ b/src/sessionWiring.ts
@@ -10,6 +10,7 @@ import type { ExecutionTimelinePanel } from "./views/executionTimeline";
 import type { SidebarPanel } from "./views/sidebarPanel";
 import { mapPhases } from "./views/sidebarState";
 import type { SidebarState } from "./views/sidebarState";
+import type { SidebarMutableState } from "./activateSidebar";
 import { deriveStatusBarFromView } from "./views/deriveStatusBar";
 
 export interface SessionWiringDeps {
@@ -27,6 +28,7 @@ export interface SessionWiringDeps {
   isActiveSession: () => boolean;
   sidebarPanel?: SidebarPanel;
   buildSidebarState?: () => SidebarState;
+  sidebarMutableState?: SidebarMutableState;
 }
 
 export function wireSessionEvents(deps: SessionWiringDeps): void {
@@ -38,19 +40,11 @@ export function wireSessionEvents(deps: SessionWiringDeps): void {
   } = deps;
 
   let lastProgress: ProgressState | undefined;
-  let sidebarCost = 0;
-  let sidebarTodoDone = 0;
-  let sidebarTodoTotal = 0;
+  const ms = deps.sidebarMutableState;
 
   function buildAndSendSidebarState(): void {
     if (!deps.sidebarPanel || !deps.buildSidebarState) return;
-    const state = deps.buildSidebarState();
-    // Merge session-local tracking data (cost/todos tracked in this closure)
-    if (state.session) {
-      if (sidebarCost > 0) state.session.cost = `$${sidebarCost.toFixed(2)}`;
-      if (sidebarTodoTotal > 0) state.session.todos = { done: sidebarTodoDone, total: sidebarTodoTotal };
-    }
-    deps.sidebarPanel.updateState(state);
+    deps.sidebarPanel.updateState(deps.buildSidebarState());
   }
 
   session.on("state-changed", (_from, to) => {
@@ -64,9 +58,11 @@ export function wireSessionEvents(deps: SessionWiringDeps): void {
 
     // Reset cost/todo/notification tracking on new run
     if (to === "running") {
-      sidebarCost = 0;
-      sidebarTodoDone = 0;
-      sidebarTodoTotal = 0;
+      if (ms) {
+        ms.cost = 0;
+        ms.todoDone = 0;
+        ms.todoTotal = 0;
+      }
       notifications.reset();
       lastProgress = undefined;
     }
@@ -176,8 +172,8 @@ export function wireSessionEvents(deps: SessionWiringDeps): void {
       deps.sidebarPanel.sendProgressUpdate({
         phases: mapPhases(progress.phases),
         elapsed: deps.elapsedTimer?.elapsed ?? "0m",
-        cost: sidebarCost > 0 ? `$${sidebarCost.toFixed(2)}` : undefined,
-        todos: sidebarTodoTotal > 0 ? { done: sidebarTodoDone, total: sidebarTodoTotal } : undefined,
+        cost: (ms?.cost ?? 0) > 0 ? `$${ms!.cost.toFixed(2)}` : undefined,
+        todos: (ms?.todoTotal ?? 0) > 0 ? { done: ms!.todoDone, total: ms!.todoTotal } : undefined,
         currentPhase: progress.currentPhaseIndex,
       });
     }
@@ -187,19 +183,19 @@ export function wireSessionEvents(deps: SessionWiringDeps): void {
     deps.liveRunPanel?.onLogAppended(content);
 
     // Extract cost and todo data for sidebar
-    if (deps.sidebarPanel && deps.isActiveSession()) {
+    if (ms && deps.sidebarPanel && deps.isActiveSession()) {
       const lines = content.split("\n");
       let updated = false;
       for (const line of lines) {
         const costMatch = line.match(/cost=\$([0-9.]+)/);
         if (costMatch) {
-          sidebarCost += parseFloat(costMatch[1]) || 0;
+          ms.cost += parseFloat(costMatch[1]) || 0;
           updated = true;
         }
         const todoMatch = line.match(/\[Todos:\s*(\d+)\/(\d+)\s+done\]/);
         if (todoMatch) {
-          sidebarTodoDone = parseInt(todoMatch[1], 10);
-          sidebarTodoTotal = parseInt(todoMatch[2], 10);
+          ms.todoDone = parseInt(todoMatch[1], 10);
+          ms.todoTotal = parseInt(todoMatch[2], 10);
           updated = true;
         }
       }
@@ -207,8 +203,8 @@ export function wireSessionEvents(deps: SessionWiringDeps): void {
         deps.sidebarPanel.sendProgressUpdate({
           phases: mapPhases(session.progress.phases),
           elapsed: deps.elapsedTimer?.elapsed ?? "0m",
-          cost: sidebarCost > 0 ? `$${sidebarCost.toFixed(2)}` : undefined,
-          todos: sidebarTodoTotal > 0 ? { done: sidebarTodoDone, total: sidebarTodoTotal } : undefined,
+          cost: ms.cost > 0 ? `$${ms.cost.toFixed(2)}` : undefined,
+          todos: ms.todoTotal > 0 ? { done: ms.todoDone, total: ms.todoTotal } : undefined,
           currentPhase: session.progress.currentPhaseIndex,
         });
       }

--- a/src/test/integration/sessionWiring.test.ts
+++ b/src/test/integration/sessionWiring.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("vscode", () => ({
+  commands: {
+    executeCommand: vi.fn(),
+  },
+}));
+
+import { SessionState } from "../../core/sessionState";
+import { wireSessionEvents, type SessionWiringDeps } from "../../sessionWiring";
+import type { SidebarMutableState } from "../../activateSidebar";
+import type { SidebarState } from "../../views/sidebarState";
+import { deriveViewState, mapPhases } from "../../views/sidebarState";
+
+function makeMutableState(): SidebarMutableState {
+  return {
+    detectionStatus: "detected",
+    planDetected: false,
+    planUserChoice: "none",
+    cachedPlanPhases: [],
+    cost: 0,
+    todoDone: 0,
+    todoTotal: 0,
+  };
+}
+
+function setup() {
+  const session = new SessionState();
+  const mutableState = makeMutableState();
+
+  function buildFullState(): SidebarState {
+    const sessionStatus = session.status;
+    const progress = session.progress;
+    const view = deriveViewState(
+      mutableState.detectionStatus,
+      sessionStatus,
+      mutableState.planDetected,
+      progress,
+      mutableState.planUserChoice,
+    );
+    return {
+      view,
+      session: sessionStatus === "running" || sessionStatus === "done" || sessionStatus === "failed" ? {
+        elapsed: "0m",
+        cost: mutableState.cost > 0 ? `$${mutableState.cost.toFixed(2)}` : undefined,
+        todos: mutableState.todoTotal > 0 ? { done: mutableState.todoDone, total: mutableState.todoTotal } : undefined,
+      } : undefined,
+      archives: [],
+    };
+  }
+
+  const sidebarPanel = { updateState: vi.fn(), sendProgressUpdate: vi.fn() } as any;
+  const deps: SessionWiringDeps = {
+    session,
+    statusBar: { update: vi.fn(), dispose: vi.fn() },
+    notifications: { onPhasesChanged: vi.fn(), reset: vi.fn() },
+    elapsedTimer: { start: vi.fn(), stop: vi.fn(), elapsed: "0m" },
+    sidebarPanel,
+    isActiveSession: () => true,
+    folderUri: "/test",
+    buildSidebarState: buildFullState,
+    sidebarMutableState: mutableState,
+  };
+  wireSessionEvents(deps);
+
+  return { session, mutableState, buildFullState, sidebarPanel };
+}
+
+describe("Cost tracking through buildFullState (issue #33)", () => {
+  it("log with cost=$0.50 → buildFullState().session.cost === '$0.50'", () => {
+    const { session, buildFullState } = setup();
+
+    session.onLockChanged({ locked: true, pid: 1 });
+    session.onProgressChanged({
+      phases: [{ number: 1, title: "Setup", status: "in_progress" }],
+      totalPhases: 1,
+      currentPhaseIndex: 0,
+    });
+
+    session.onLogAppended("[Session: model=haiku cost=$0.50 duration=2s]\n");
+
+    const state = buildFullState();
+    expect(state.session?.cost).toBe("$0.50");
+  });
+
+  it("cost accumulates across multiple log lines", () => {
+    const { session, buildFullState } = setup();
+
+    session.onLockChanged({ locked: true, pid: 1 });
+    session.onProgressChanged({
+      phases: [{ number: 1, title: "Setup", status: "in_progress" }],
+      totalPhases: 1,
+      currentPhaseIndex: 0,
+    });
+
+    session.onLogAppended("cost=$0.30\n");
+    session.onLogAppended("cost=$0.20\n");
+
+    const state = buildFullState();
+    expect(state.session?.cost).toBe("$0.50");
+  });
+
+  it("cost present in completed state", () => {
+    const { session, buildFullState } = setup();
+
+    session.onLockChanged({ locked: true, pid: 1 });
+    session.onProgressChanged({
+      phases: [{ number: 1, title: "Setup", status: "in_progress" }],
+      totalPhases: 1,
+      currentPhaseIndex: 0,
+    });
+    session.onLogAppended("cost=$0.75\n");
+
+    // Complete the run
+    session.onProgressChanged({
+      phases: [{ number: 1, title: "Setup", status: "completed" }],
+      totalPhases: 1,
+    });
+    session.onLockChanged({ locked: false });
+
+    expect(session.status).toBe("done");
+    const state = buildFullState();
+    expect(state.session?.cost).toBe("$0.75");
+  });
+
+  it("cost resets on new run", () => {
+    const { session, buildFullState } = setup();
+
+    // First run
+    session.onLockChanged({ locked: true, pid: 1 });
+    session.onProgressChanged({
+      phases: [{ number: 1, title: "Setup", status: "in_progress" }],
+      totalPhases: 1,
+      currentPhaseIndex: 0,
+    });
+    session.onLogAppended("cost=$0.50\n");
+    session.onProgressChanged({
+      phases: [{ number: 1, title: "Setup", status: "completed" }],
+      totalPhases: 1,
+    });
+    session.onLockChanged({ locked: false });
+    session.reset();
+
+    // Second run — cost should be fresh
+    session.onLockChanged({ locked: true, pid: 2 });
+    session.onProgressChanged({
+      phases: [{ number: 1, title: "Build", status: "in_progress" }],
+      totalPhases: 1,
+      currentPhaseIndex: 0,
+    });
+    session.onLogAppended("cost=$0.10\n");
+
+    const state = buildFullState();
+    expect(state.session?.cost).toBe("$0.10");
+  });
+
+  it("todo tracking flows through buildFullState", () => {
+    const { session, buildFullState } = setup();
+
+    session.onLockChanged({ locked: true, pid: 1 });
+    session.onProgressChanged({
+      phases: [{ number: 1, title: "Setup", status: "in_progress" }],
+      totalPhases: 1,
+      currentPhaseIndex: 0,
+    });
+
+    session.onLogAppended("[Todos: 3/5 done]\n");
+
+    const state = buildFullState();
+    expect(state.session?.todos).toEqual({ done: 3, total: 5 });
+  });
+});

--- a/src/test/integration/stateSync.test.ts
+++ b/src/test/integration/stateSync.test.ts
@@ -22,6 +22,18 @@ function makeProgress(
   };
 }
 
+function makeMutableState() {
+  return {
+    detectionStatus: "detected" as const,
+    planDetected: false,
+    planUserChoice: "none" as const,
+    cachedPlanPhases: [] as any[],
+    cost: 0,
+    todoDone: 0,
+    todoTotal: 0,
+  };
+}
+
 function wireDeps(
   session: SessionState,
   getSidebarView: () => SidebarView,
@@ -42,6 +54,7 @@ function wireDeps(
       archives: [],
     }),
     sidebarPanel: { updateState: vi.fn(), sendProgressUpdate: vi.fn() } as any,
+    sidebarMutableState: makeMutableState(),
   };
   wireSessionEvents(deps);
   return { statusBarUpdates };
@@ -241,6 +254,7 @@ function wireWithRealNotifications(
       archives: [],
     }),
     sidebarPanel: { updateState: vi.fn(), sendProgressUpdate: vi.fn() } as any,
+    sidebarMutableState: makeMutableState(),
   };
   wireSessionEvents(deps);
   return { statusBarUpdates, mockWindow, notifications };

--- a/src/test/unit/views/sessionWiringLog.test.ts
+++ b/src/test/unit/views/sessionWiringLog.test.ts
@@ -8,6 +8,19 @@ vi.mock("vscode", () => ({
 
 import { SessionState } from "../../../core/sessionState";
 import { wireSessionEvents, type SessionWiringDeps } from "../../../sessionWiring";
+import type { SidebarMutableState } from "../../../activateSidebar";
+
+function makeMutableState(): SidebarMutableState {
+  return {
+    detectionStatus: "detected",
+    planDetected: false,
+    planUserChoice: "none",
+    cachedPlanPhases: [],
+    cost: 0,
+    todoDone: 0,
+    todoTotal: 0,
+  };
+}
 
 describe("wireSessionEvents — uses buildSidebarState for sidebar updates", () => {
   it("calls buildSidebarState on session state change and merges cost/todos", () => {
@@ -28,6 +41,7 @@ describe("wireSessionEvents — uses buildSidebarState for sidebar updates", () 
       isActiveSession: () => true,
       folderUri: "/test",
       buildSidebarState,
+      sidebarMutableState: makeMutableState(),
     };
     wireSessionEvents(deps);
 
@@ -44,10 +58,12 @@ describe("wireSessionEvents — uses buildSidebarState for sidebar updates", () 
 describe("wireSessionEvents — log-appended handler", () => {
   let session: SessionState;
   let deps: SessionWiringDeps;
+  let mutableState: SidebarMutableState;
 
   beforeEach(() => {
     vi.clearAllMocks();
     session = new SessionState();
+    mutableState = makeMutableState();
     deps = {
       session,
       statusBar: { update: vi.fn(), dispose: vi.fn() },
@@ -56,10 +72,7 @@ describe("wireSessionEvents — log-appended handler", () => {
       sidebarPanel: { updateState: vi.fn(), sendProgressUpdate: vi.fn() } as any,
       isActiveSession: () => true,
       folderUri: "/test",
-      detectionStatus: "detected" as const,
-      planDetected: false,
-      getArchives: () => [],
-      getPlanUserChoice: () => "none" as const,
+      sidebarMutableState: mutableState,
     };
     wireSessionEvents(deps);
 
@@ -134,5 +147,30 @@ describe("wireSessionEvents — log-appended handler", () => {
     expect(deps.sidebarPanel!.sendProgressUpdate).toHaveBeenCalledWith(
       expect.objectContaining({ cost: "$0.05" }),
     );
+  });
+
+  it("writes cost to sidebarMutableState", () => {
+    session.onLogAppended("cost=$0.05\n");
+    expect(mutableState.cost).toBeCloseTo(0.05);
+  });
+
+  it("writes todo to sidebarMutableState", () => {
+    session.onLogAppended("[Todos: 3/5 done]\n");
+    expect(mutableState.todoDone).toBe(3);
+    expect(mutableState.todoTotal).toBe(5);
+  });
+
+  it("resets sidebarMutableState cost on new run", () => {
+    session.onLogAppended("cost=$0.05\n");
+    expect(mutableState.cost).toBeCloseTo(0.05);
+
+    // New run
+    session.onLockChanged({ locked: false, pid: 0 });
+    session.reset();
+    session.onLockChanged({ locked: true, pid: 2 });
+
+    expect(mutableState.cost).toBe(0);
+    expect(mutableState.todoDone).toBe(0);
+    expect(mutableState.todoTotal).toBe(0);
   });
 });

--- a/src/test/unit/views/walkthrough.test.ts
+++ b/src/test/unit/views/walkthrough.test.ts
@@ -151,6 +151,7 @@ describe("walkthrough step completion", () => {
         } as any,
         folderUri: "file:///test",
         isActiveSession: () => true,
+        sidebarMutableState: { detectionStatus: "detected", planDetected: false, planUserChoice: "none", cachedPlanPhases: [], cost: 0, todoDone: 0, todoTotal: 0 },
       };
 
       wireSessionEvents(wiringDeps);


### PR DESCRIPTION
## Summary

- Move cost/todo tracking from closure variables in `sessionWiring.ts` to `SidebarMutableState` fields
- `buildFullState()` now includes cost natively, fixing all callers: MCP bridge, `onArchiveDone`, webview init/ready
- Previously `session.cost` was always `undefined` because cost was accumulated in a closure variable inaccessible to `buildFullState()`

Closes #33

## Test plan

- [x] 5 new integration tests in `src/test/integration/sessionWiring.test.ts` (cost flows through buildFullState, accumulates, persists in completed state, resets on new run, todos flow through)
- [x] 3 new unit test assertions in `sessionWiringLog.test.ts` (mutable state writes, reset)
- [x] All 886 tests pass
- [x] Visual verification in EDH: cost visible during running ($0.09) and in completed state ($5.98) via MCP bridge